### PR TITLE
New feature awaiting review on OpenStack gerrit

### DIFF
--- a/jenkins_jobs/modules/project_multibranch.py
+++ b/jenkins_jobs/modules/project_multibranch.py
@@ -270,7 +270,9 @@ class WorkflowMultiBranch(jenkins_jobs.modules.base.Base):
             'class': self.jenkins_class,
             'reference': '../..'
         })
-        XML.SubElement(factory, 'scriptPath').text = 'Jenkinsfile'
+        XML.SubElement(factory, 'scriptPath').text = data.get(
+            'script-path', 'Jenkinsfile'
+        )
 
         return xml_parent
 
@@ -441,6 +443,7 @@ def git_scm(xml_parent, data):
     ##########
 
     traits_path = 'jenkins.plugins.git.traits'
+    hudson_traits_path = 'hudson.plugins.git.extensions.impl'
     traits = XML.SubElement(source, 'traits')
 
     if data.get('discover-branches', True):
@@ -450,6 +453,27 @@ def git_scm(xml_parent, data):
         XML.SubElement(
             traits, ''.join([traits_path, '.IgnoreOnPushNotificationTrait']))
 
+    if data.get('clean-before-checkout', False):
+        cbct = XML.SubElement(
+            traits, ''.join([traits_path, '.CleanBeforeCheckoutTrait']))
+        XML.SubElement(
+            cbct, 'extension', {
+                'class': ''.join([hudson_traits_path, '.CleanBeforeCheckout'])})
+
+    if data.get('clean-after-checkout', False):
+        cact = XML.SubElement(
+            traits, ''.join([traits_path, '.CleanAfterCheckoutTrait']))
+        XML.SubElement(
+            cact, 'extension', {
+                'class': ''.join([hudson_traits_path, '.CleanCheckout'])})
+
+    if data.get('local-branch', False):
+        lbt = XML.SubElement(
+            traits, ''.join([traits_path, '.LocalBranchTrait']))
+        lb = XML.SubElement(
+            lbt, 'extension', {
+                'class': ''.join([hudson_traits_path, '.LocalBranch'])})
+        XML.SubElement(lb, 'localBranch').text = data.get('local-branch')
 
 def github_scm(xml_parent, data):
     """Configure GitHub SCM

--- a/jenkins_jobs/modules/project_multibranch.py
+++ b/jenkins_jobs/modules/project_multibranch.py
@@ -86,8 +86,22 @@ class WorkflowMultiBranch(jenkins_jobs.modules.base.Base):
     def root_xml(self, data):
         xml_parent = XML.Element(self.jenkins_class)
         xml_parent.attrib['plugin'] = 'workflow-multibranch'
-        XML.SubElement(xml_parent, 'properties')
-
+        props = XML.SubElement(xml_parent, 'properties')
+        if data.get('blueocean-plugin', False):
+            plugin = XML.SubElement(props, ''.join(['io.jenkins.blueocean.',
+                'rest.impl.pipeline.credential.BlueOceanCredentialsProvider_',
+                '-FolderPropertyImpl']), {
+                'plugin': 'blueocean-pipeline-scm-api'})
+            domain = XML.SubElement(plugin, 'domain', {
+                'plugin': 'credentials'})
+            XML.SubElement(domain, 'name').text = data.get(
+                'blueocean-plugin').get('domain-name', '')
+            XML.SubElement(domain, 'description').text = 'Blue Ocean'
+            XML.SubElement(domain, 'specifications')
+            XML.SubElement(plugin, 'user').text = data.get(
+                'blueocean-plugin').get('user', '')
+            XML.SubElement(plugin, 'id').text = data.get(
+                'blueocean-plugin').get('id', '')
         #########
         # Views #
         #########
@@ -458,7 +472,9 @@ def git_scm(xml_parent, data):
             traits, ''.join([traits_path, '.CleanBeforeCheckoutTrait']))
         XML.SubElement(
             cbct, 'extension', {
-                'class': ''.join([hudson_traits_path, '.CleanBeforeCheckout'])})
+                'class': ''.join([hudson_traits_path, '.CleanBeforeCheckout'])
+            }
+        )
 
     if data.get('clean-after-checkout', False):
         cact = XML.SubElement(
@@ -474,6 +490,7 @@ def git_scm(xml_parent, data):
             lbt, 'extension', {
                 'class': ''.join([hudson_traits_path, '.LocalBranch'])})
         XML.SubElement(lb, 'localBranch').text = data.get('local-branch')
+
 
 def github_scm(xml_parent, data):
     """Configure GitHub SCM


### PR DESCRIPTION
# Blueocean configuration for multibranch project
    
Allow a proper BlueOcean credentials configuration for multibranch project.
If the blueocean parameter is present in the yaml file, the job builder will add the whole plugin configuration in the header of the job.
    
The configurable elements are :
+ the credential domain name
+ the user
+ the credential id
    
How to use it, a job sample :
```yaml
        - job:
            name: NameOfTheJob
            project-type: multibranch
    
            blueocean-plugin:
                user: admin
                id: jenkins-generated-ssh-key
                domain-name: blueocean-folder-credential-domain
            script-path: path/to/the/Jenkinsfile
            scm:
            - git:
                url: git@server:repo
                credentials-id: jenkins-generated-ssh-key
                discover-branches: true
                clean-before-checkout: true
                clean-after-checkout: true
                local-branch: '**'
```
    
> Openstack : Change-Id: I8338c77501b8e756992a896fd5f50d7929f86c96

----

# Enhances configuration for multibranch project
    
Allow a configurable script-path for the Jenkinsfile location
Allow a standard blueocean configuration for a git scm :
+ clean before checkout
+ clean after checkout
+ local branch matching
    
How to use it, a job sample :
```yaml
        - job:
            name: NameOfTheJob
            project-type: multibranch
    
            script-path: path/to/the/Jenkinsfile
            scm:
            - git:
                url: git@server:repo
                discover-branches: true
                clean-before-checkout: true
                clean-after-checkout: true
                local-branch: '**'
```

> Openstack : Change-Id: Idb045f7c28efb84f990240d71a97853dace58090